### PR TITLE
Add file overwrite protection and --overwrite option

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,29 @@ vtt2minutes meeting.vtt --prompt-template custom_template.txt
 
 # ChatGPT用プロンプトファイルを生成（Bedrockを使わない）
 vtt2minutes meeting.vtt --chat-prompt-file prompt.txt
+
+# 既存ファイルを上書きする
+vtt2minutes meeting.vtt --overwrite
 ```
+
+### ファイルの上書き
+
+デフォルトでは、出力ファイルが既に存在する場合はエラーが発生します。既存ファイルを上書きするには `--overwrite` オプションを使用してください：
+
+```bash
+# 既存の出力ファイルを上書き
+vtt2minutes meeting.vtt --overwrite
+
+# 既存の中間ファイルやプロンプトファイルも上書き
+vtt2minutes meeting.vtt --intermediate-file processed.md --chat-prompt-file prompt.txt --overwrite
+```
+
+このオプションは以下のファイルの上書きを許可します：
+- **出力ファイル**: 生成される議事録ファイル（`.md`）
+- **中間ファイル**: 前処理済みトランスクリプトファイル（`--intermediate-file`）
+- **プロンプトファイル**: ChatGPT用プロンプトファイル（`--chat-prompt-file`）
+
+**注意**: `--overwrite` オプションを使用すると、既存のファイルが警告なしに上書きされるため、重要なファイルのバックアップを事前に取ることをお勧めします。
 
 ### ChatGPT等のチャット型AIサービス向け機能
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1209,3 +1209,389 @@ class TestCLI:
             assert result.exit_code == 1
             # RuntimeError during VTT parsing shows specific error, not generic
             assert "VTTファイルの解析に失敗しました" in result.output
+
+    def test_overwrite_option_help(self) -> None:
+        """Test that --overwrite option appears in help."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--overwrite" in result.output
+        assert "Overwrite existing output files" in result.output
+
+    @patch("vtt2minutes.cli.VTTParser")
+    @patch("vtt2minutes.cli.TextPreprocessor")
+    @patch("vtt2minutes.cli.IntermediateTranscriptWriter")
+    def test_output_file_exists_without_overwrite(
+        self,
+        mock_writer: Mock,
+        mock_preprocessor: Mock,
+        mock_parser: Mock,
+    ) -> None:
+        """Test error when output file exists and --overwrite is not used."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_file = Path(temp_dir) / "test.vtt"
+            input_file.write_text(
+                "WEBVTT\n\n00:00.000 --> 00:05.000\nSpeaker: Hello", encoding="utf-8"
+            )
+
+            output_file = Path(temp_dir) / "output.md"
+            # Create existing output file
+            output_file.write_text("Existing content", encoding="utf-8")
+
+            # Mock components
+            mock_cue = Mock()
+            mock_parser_instance = Mock()
+            mock_parser_instance.parse_file.return_value = [mock_cue]
+            mock_parser_instance.get_speakers.return_value = ["Speaker"]
+            mock_parser_instance.get_duration.return_value = 5.0
+            mock_parser.return_value = mock_parser_instance
+
+            mock_preprocessor_instance = Mock()
+            mock_preprocessor_instance.preprocess_cues.return_value = [mock_cue]
+            mock_preprocessor.return_value = mock_preprocessor_instance
+
+            mock_writer_instance = Mock()
+            mock_writer_instance.get_statistics.return_value = {
+                "speakers": ["Speaker"],
+                "duration": 5.0,
+                "word_count": 2,
+            }
+            mock_writer_instance.format_duration.return_value = "00:00:05"
+            # Mock write_markdown to create actual file
+            def mock_write_markdown(
+                cues: list[Any], path: Path, title: str, metadata: dict[str, Any]
+            ) -> None:
+                del cues, title, metadata  # Mark as used
+                content = "# Mock Intermediate Content\n\nSpeaker: Hello"
+                path.write_text(content, encoding="utf-8")
+
+            mock_writer_instance.write_markdown.side_effect = mock_write_markdown
+            mock_writer.return_value = mock_writer_instance
+
+            result = runner.invoke(
+                main,
+                [
+                    str(input_file),
+                    "-o", 
+                    str(output_file),
+                    "--chat-prompt-file",
+                    "prompt.txt",
+                ],
+            )
+
+            assert result.exit_code == 1
+            assert "中間ファイルの保存に失敗しました" in result.output
+
+    @patch("vtt2minutes.cli.VTTParser")
+    @patch("vtt2minutes.cli.TextPreprocessor")
+    @patch("vtt2minutes.cli.IntermediateTranscriptWriter")
+    def test_output_file_exists_with_overwrite(
+        self,
+        mock_writer: Mock,
+        mock_preprocessor: Mock,
+        mock_parser: Mock,
+    ) -> None:
+        """Test successful overwrite when output file exists and --overwrite is used."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_file = Path(temp_dir) / "test.vtt"
+            input_file.write_text(
+                "WEBVTT\n\n00:00.000 --> 00:05.000\nSpeaker: Hello", encoding="utf-8"
+            )
+
+            output_file = Path(temp_dir) / "output.md"
+            # Create existing output file
+            output_file.write_text("Existing content", encoding="utf-8")
+
+            # Mock components
+            mock_cue = Mock()
+            mock_parser_instance = Mock()
+            mock_parser_instance.parse_file.return_value = [mock_cue]
+            mock_parser_instance.get_speakers.return_value = ["Speaker"]
+            mock_parser_instance.get_duration.return_value = 5.0
+            mock_parser.return_value = mock_parser_instance
+
+            mock_preprocessor_instance = Mock()
+            mock_preprocessor_instance.preprocess_cues.return_value = [mock_cue]
+            mock_preprocessor.return_value = mock_preprocessor_instance
+
+            mock_writer_instance = Mock()
+            mock_writer_instance.get_statistics.return_value = {
+                "speakers": ["Speaker"],
+                "duration": 5.0,
+                "word_count": 2,
+            }
+            mock_writer_instance.format_duration.return_value = "00:00:05"
+            # Mock write_markdown to create actual file
+            def mock_write_markdown(
+                cues: list[Any], path: Path, title: str, metadata: dict[str, Any]
+            ) -> None:
+                del cues, title, metadata  # Mark as used
+                content = "# Mock Intermediate Content\n\nSpeaker: Hello"
+                path.write_text(content, encoding="utf-8")
+
+            mock_writer_instance.write_markdown.side_effect = mock_write_markdown
+            mock_writer.return_value = mock_writer_instance
+
+            chat_prompt_file = Path(temp_dir) / "prompt.txt"
+
+            result = runner.invoke(
+                main,
+                [
+                    str(input_file),
+                    "-o", 
+                    str(output_file),
+                    "--chat-prompt-file",
+                    str(chat_prompt_file),
+                    "--overwrite",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert "チャットプロンプトファイルが正常に生成されました" in result.output
+
+    @patch("vtt2minutes.cli.VTTParser")
+    @patch("vtt2minutes.cli.TextPreprocessor")
+    @patch("vtt2minutes.cli.IntermediateTranscriptWriter")
+    def test_intermediate_file_exists_without_overwrite(
+        self,
+        mock_writer: Mock,
+        mock_preprocessor: Mock,
+        mock_parser: Mock,
+    ) -> None:
+        """Test error when intermediate file exists and --overwrite is not used."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_file = Path(temp_dir) / "test.vtt"
+            input_file.write_text(
+                "WEBVTT\n\n00:00.000 --> 00:05.000\nSpeaker: Hello", encoding="utf-8"
+            )
+
+            intermediate_file = Path(temp_dir) / "intermediate.md"
+            # Create existing intermediate file
+            intermediate_file.write_text("Existing intermediate", encoding="utf-8")
+
+            # Mock components
+            mock_cue = Mock()
+            mock_parser_instance = Mock()
+            mock_parser_instance.parse_file.return_value = [mock_cue]
+            mock_parser_instance.get_speakers.return_value = ["Speaker"]
+            mock_parser_instance.get_duration.return_value = 5.0
+            mock_parser.return_value = mock_parser_instance
+
+            mock_preprocessor_instance = Mock()
+            mock_preprocessor_instance.preprocess_cues.return_value = [mock_cue]
+            mock_preprocessor.return_value = mock_preprocessor_instance
+
+            mock_writer_instance = Mock()
+            mock_writer_instance.get_statistics.return_value = {
+                "speakers": ["Speaker"],
+                "duration": 5.0,
+                "word_count": 2,
+            }
+            mock_writer_instance.format_duration.return_value = "00:00:05"
+            mock_writer.return_value = mock_writer_instance
+
+            result = runner.invoke(
+                main,
+                [
+                    str(input_file),
+                    "--intermediate-file",
+                    str(intermediate_file),
+                    "--chat-prompt-file",
+                    "prompt.txt",
+                ],
+            )
+
+            assert result.exit_code == 1
+            assert "中間ファイルの保存に失敗しました" in result.output
+
+    @patch("vtt2minutes.cli.VTTParser")
+    @patch("vtt2minutes.cli.TextPreprocessor")
+    @patch("vtt2minutes.cli.IntermediateTranscriptWriter")
+    def test_chat_prompt_file_exists_without_overwrite(
+        self,
+        mock_writer: Mock,
+        mock_preprocessor: Mock,
+        mock_parser: Mock,
+    ) -> None:
+        """Test error when chat prompt file exists and --overwrite is not used."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_file = Path(temp_dir) / "test.vtt"
+            input_file.write_text(
+                "WEBVTT\n\n00:00.000 --> 00:05.000\nSpeaker: Hello", encoding="utf-8"
+            )
+
+            chat_prompt_file = Path(temp_dir) / "prompt.txt"
+            # Create existing chat prompt file
+            chat_prompt_file.write_text("Existing prompt", encoding="utf-8")
+
+            # Mock components
+            mock_cue = Mock()
+            mock_parser_instance = Mock()
+            mock_parser_instance.parse_file.return_value = [mock_cue]
+            mock_parser_instance.get_speakers.return_value = ["Speaker"]
+            mock_parser_instance.get_duration.return_value = 5.0
+            mock_parser.return_value = mock_parser_instance
+
+            mock_preprocessor_instance = Mock()
+            mock_preprocessor_instance.preprocess_cues.return_value = [mock_cue]
+            mock_preprocessor.return_value = mock_preprocessor_instance
+
+            mock_writer_instance = Mock()
+            mock_writer_instance.get_statistics.return_value = {
+                "speakers": ["Speaker"],
+                "duration": 5.0,
+                "word_count": 2,
+            }
+            mock_writer_instance.format_duration.return_value = "00:00:05"
+            # Mock write_markdown to create actual file
+            def mock_write_markdown(
+                cues: list[Any], path: Path, title: str, metadata: dict[str, Any]
+            ) -> None:
+                del cues, title, metadata  # Mark as used
+                content = "# Mock Intermediate Content\n\nSpeaker: Hello"
+                path.write_text(content, encoding="utf-8")
+
+            mock_writer_instance.write_markdown.side_effect = mock_write_markdown
+            mock_writer.return_value = mock_writer_instance
+
+            result = runner.invoke(
+                main,
+                [
+                    str(input_file),
+                    "--chat-prompt-file",
+                    str(chat_prompt_file),
+                ],
+            )
+
+            assert result.exit_code == 1
+            assert "チャットプロンプトファイルの生成に失敗しました" in result.output
+
+    @patch("vtt2minutes.cli.VTTParser")
+    @patch("vtt2minutes.cli.TextPreprocessor")
+    @patch("vtt2minutes.cli.IntermediateTranscriptWriter")
+    @patch("vtt2minutes.cli.BedrockMeetingMinutesGenerator")
+    def test_final_output_file_exists_without_overwrite(
+        self,
+        mock_bedrock: Mock,
+        mock_writer: Mock,
+        mock_preprocessor: Mock,
+        mock_parser: Mock,
+    ) -> None:
+        """Test error when final output file exists and --overwrite is not used."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_file = Path(temp_dir) / "test.vtt"
+            input_file.write_text(
+                "WEBVTT\n\n00:00.000 --> 00:05.000\nSpeaker: Hello", encoding="utf-8"
+            )
+
+            output_file = Path(temp_dir) / "output.md"
+            # Create existing output file
+            output_file.write_text("Existing content", encoding="utf-8")
+
+            # Mock components
+            mock_cue = Mock()
+            mock_parser_instance = Mock()
+            mock_parser_instance.parse_file.return_value = [mock_cue]
+            mock_parser_instance.get_speakers.return_value = ["Speaker"]
+            mock_parser_instance.get_duration.return_value = 5.0
+            mock_parser.return_value = mock_parser_instance
+
+            mock_preprocessor_instance = Mock()
+            mock_preprocessor_instance.preprocess_cues.return_value = [mock_cue]
+            mock_preprocessor.return_value = mock_preprocessor_instance
+
+            mock_writer_instance = self._create_mock_writer_with_file_creation()
+            mock_writer.return_value = mock_writer_instance
+
+            mock_bedrock_instance = Mock()
+            mock_bedrock_instance.generate_minutes_from_markdown.return_value = (
+                "# Generated Minutes"
+            )
+            mock_bedrock.return_value = mock_bedrock_instance
+
+            result = runner.invoke(
+                main,
+                [
+                    str(input_file),
+                    "-o",
+                    str(output_file),
+                    "--bedrock-model",
+                    "anthropic.claude-3-haiku-20240307-v1:0",
+                ],
+            )
+
+            assert result.exit_code == 1
+            assert "ファイルの保存に失敗しました" in result.output
+
+    @patch("vtt2minutes.cli.VTTParser")
+    @patch("vtt2minutes.cli.TextPreprocessor")
+    @patch("vtt2minutes.cli.IntermediateTranscriptWriter")
+    @patch("vtt2minutes.cli.BedrockMeetingMinutesGenerator")
+    def test_final_output_file_exists_with_overwrite(
+        self,
+        mock_bedrock: Mock,
+        mock_writer: Mock,
+        mock_preprocessor: Mock,
+        mock_parser: Mock,
+    ) -> None:
+        """Test successful overwrite when final output file exists and --overwrite is used."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_file = Path(temp_dir) / "test.vtt"
+            input_file.write_text(
+                "WEBVTT\n\n00:00.000 --> 00:05.000\nSpeaker: Hello", encoding="utf-8"
+            )
+
+            output_file = Path(temp_dir) / "output.md"
+            # Create existing output file
+            output_file.write_text("Existing content", encoding="utf-8")
+
+            # Mock components
+            mock_cue = Mock()
+            mock_parser_instance = Mock()
+            mock_parser_instance.parse_file.return_value = [mock_cue]
+            mock_parser_instance.get_speakers.return_value = ["Speaker"]
+            mock_parser_instance.get_duration.return_value = 5.0
+            mock_parser.return_value = mock_parser_instance
+
+            mock_preprocessor_instance = Mock()
+            mock_preprocessor_instance.preprocess_cues.return_value = [mock_cue]
+            mock_preprocessor.return_value = mock_preprocessor_instance
+
+            mock_writer_instance = self._create_mock_writer_with_file_creation()
+            mock_writer.return_value = mock_writer_instance
+
+            mock_bedrock_instance = Mock()
+            mock_bedrock_instance.generate_minutes_from_markdown.return_value = (
+                "# Generated Minutes"
+            )
+            mock_bedrock.return_value = mock_bedrock_instance
+
+            result = runner.invoke(
+                main,
+                [
+                    str(input_file),
+                    "-o",
+                    str(output_file),
+                    "--bedrock-model",
+                    "anthropic.claude-3-haiku-20240307-v1:0",
+                    "--overwrite",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert "AI議事録生成が完了しました" in result.output
+            # Verify the output file was overwritten
+            assert output_file.read_text(encoding="utf-8") == "# Generated Minutes"


### PR DESCRIPTION
## Summary
- ファイル上書き保護機能の追加と `--overwrite` オプションの実装
- 出力ファイル、中間ファイル、チャットプロンプトファイルの上書き制御
- READMEにファイル上書きオプションの詳細説明を追加
- bedrock.pyのテストカバレッジ改善（84.08% → 88.06%）

## Test plan
- [x] 全テスト（143個）がパス
- [x] テストカバレッジが85%以上を維持
- [x] `--overwrite` オプションの動作確認（エラー時・成功時）
- [x] 既存機能への影響なし
- [x] READMEドキュメント更新

## Changes
- CLI に `--overwrite` フラグを追加
- ファイル存在チェックとエラーハンドリングを各保存関数に実装
- bedrock.py 用の新しいテストケースを追加（inference profile、session token等）
- CLIテストの修正（UUID使用、`--overwrite` フラグ追加）
- README に `--overwrite` オプションの包括的なドキュメント追加