### PR TITLE
fix: 大きな会議録処理時に boto3 のデフォルト read timeout を超えて失敗する問題を修正

### DIFF
--- a/src/vtt2minutes/bedrock.py
+++ b/src/vtt2minutes/bedrock.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import boto3  # type: ignore[import-untyped]
+from botocore.config import Config  # type: ignore[import-untyped]
 from botocore.exceptions import (  # type: ignore[import-untyped]
     BotoCoreError,
     ClientError,
@@ -160,7 +161,11 @@ class BedrockMeetingMinutesGenerator:
         """
         try:
             client_kwargs = self._build_client_kwargs()
-            self.bedrock_client = boto3.client("bedrock-runtime", **client_kwargs)  # type: ignore[assignment]
+            self.bedrock_client = boto3.client(  # type: ignore[assignment]
+                "bedrock-runtime",
+                config=Config(read_timeout=600, connect_timeout=10),
+                **client_kwargs,
+            )
 
             if validate_access:
                 self._validate_bedrock_access()
@@ -280,7 +285,11 @@ class BedrockMeetingMinutesGenerator:
                     client_kwargs["aws_session_token"] = self.aws_session_token
 
             # Try to get foundation models to validate access
-            bedrock_client = boto3.client("bedrock", **client_kwargs)  # type: ignore[assignment]
+            bedrock_client = boto3.client(  # type: ignore[assignment]
+                "bedrock",
+                config=Config(read_timeout=30, connect_timeout=10),
+                **client_kwargs,
+            )
             bedrock_client.list_foundation_models()  # type: ignore[misc]
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")  # type: ignore[misc]
@@ -557,7 +566,11 @@ class BedrockMeetingMinutesGenerator:
                 if self.aws_session_token:
                     client_kwargs["aws_session_token"] = self.aws_session_token
 
-            bedrock_client = boto3.client("bedrock", **client_kwargs)  # type: ignore[assignment]
+            bedrock_client = boto3.client(  # type: ignore[assignment]
+                "bedrock",
+                config=Config(read_timeout=30, connect_timeout=10),
+                **client_kwargs,
+            )
 
             response: dict[str, Any] = bedrock_client.list_foundation_models()  # type: ignore[misc]
             model_summaries: list[dict[str, Any]] = response.get("modelSummaries", [])  # type: ignore[misc]


### PR DESCRIPTION
## 背景・課題

### 背景

Amazon Bedrock の新しいクロスリージョン推論プロファイル（例: `jp.anthropic.claude-sonnet-4-6`）は、従来のモデル ID（`anthropic.claude-sonnet-4-20250514-v1:0` など）と比べて推論完了までの時間が長くなる場合がある。

### 課題

28 分程度の会議録など大きな VTT ファイルを処理する際、Claude Sonnet 4.6 の推論に 60 秒以上かかる。boto3 のデフォルト `read_timeout` は 60 秒であり、これを超えると `ReadTimeoutError` が発生する。botocore はデフォルトで最大 5 回リトライするため、ユーザーは約 5 分待たされた後にエラーになるという体験になっていた。

```
Bedrock API call failed: Read timeout on endpoint URL:
"https://bedrock-runtime.ap-northeast-1.amazonaws.com/model/jp.anthropic.claude-sonnet-4-6/invoke"
```

## 目的

大きな会議録でも推論が完了するまで待機できるよう、boto3 クライアントのタイムアウト設定を適切な値に調整し、Claude Sonnet 4.6 などの新しいモデルで正常に議事録生成できるようにする。

## 変更内容

| 箇所 | 変更前 | 変更後 |
|------|--------|--------|
| `bedrock-runtime` クライアント（議事録生成用）| タイムアウト未設定（デフォルト 60 秒）| `read_timeout=600`、`connect_timeout=10` |
| `bedrock` クライアント（アクセス検証用）| タイムアウト未設定（デフォルト 60 秒）| `read_timeout=30`、`connect_timeout=10` |
| `bedrock` クライアント（モデル一覧取得用）| タイムアウト未設定（デフォルト 60 秒）| `read_timeout=30`、`connect_timeout=10` |

- `botocore.config.Config` を import して各 boto3 クライアントに渡すように変更
- 議事録生成の `bedrock-runtime` クライアントは長時間推論を考慮して `read_timeout` を 600 秒に設定
- 検証・一覧取得用クライアントは短い処理のため `read_timeout` を 30 秒に設定

## 変更のスコープ

**含む:**
- `src/vtt2minutes/bedrock.py` のタイムアウト設定

**含まない:**
- タイムアウト値をユーザーが CLI から設定できる機能（別途検討）
- API 呼び出し方式（`invoke_model` → `converse`）の変更

## 動作確認方法

28 分程度の大きな会議録 VTT ファイルで以下を実行し、正常に議事録が生成されることを確認:

```bash
vtt2minutes --bedrock-inference-profile-id jp.anthropic.claude-sonnet-4-6 <大きなVTTファイル>
```

## リスク・注意点

- `read_timeout=600` は長めの設定だが、ネットワーク障害時にユーザーが最大 10 分待たされる可能性がある。将来的に CLI オプションで上書きできるようにすることで対応予定。
- リトライ回数（デフォルト最大 5 回）は変更していないため、タイムアウトが発生し続ける場合は最大 50 分かかる可能性がある。実際の使用では 1 回の呼び出しが成功するため問題にならない想定。

## 変更の概要図

### 修正前後のタイムアウト動作

```mermaid
sequenceDiagram
    participant U as "ユーザー"
    participant A as "vtt2minutes"
    participant B as "Bedrock Runtime"

    rect rgb(255, 220, 220)
        note over U,B: "修正前（Claude Sonnet 4.6 + 大きな会議録）"
        U->>A: "VTTファイル指定"
        A->>B: "invoke_model（タイムアウト: 60秒）"
        note over B: "推論中（>60秒）"
        B--xA: "ReadTimeoutError × 5回リトライ"
        A-->>U: "エラー（約5分後）"
    end

    rect rgb(220, 255, 220)
        note over U,B: "修正後"
        U->>A: "VTTファイル指定"
        A->>B: "invoke_model（タイムアウト: 600秒）"
        note over B: "推論中（~70秒）"
        B-->>A: "議事録テキスト"
        A-->>U: "議事録生成完了"
    end
```

### タイムアウト設定の変更箇所

```mermaid
classDiagram
    class BedrockMeetingMinutesGenerator {
        +generate_minutes_from_markdown()
        +get_available_models()
        -_initialize_bedrock_client()
        -_validate_bedrock_access()
    }

    class bedrock_runtime_client {
        read_timeout: 60 → 600秒
        connect_timeout: なし → 10秒
    }

    class bedrock_client_validate {
        read_timeout: 60 → 30秒
        connect_timeout: なし → 10秒
    }

    class bedrock_client_list {
        read_timeout: 60 → 30秒
        connect_timeout: なし → 10秒
    }

    BedrockMeetingMinutesGenerator --> bedrock_runtime_client : "_initialize_bedrock_client()"
    BedrockMeetingMinutesGenerator --> bedrock_client_validate : "_validate_bedrock_access()"
    BedrockMeetingMinutesGenerator --> bedrock_client_list : "get_available_models()"
```