### PR TITLE
chore: devcontainerのNode.jsセットアップを修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,15 @@
 FROM mcr.microsoft.com/devcontainers/python:3.12-bookworm
 
+# Remove problematic Yarn repository if it exists
+RUN rm -f /etc/apt/sources.list.d/yarn.list
+
 # Install system dependencies including Node.js
 RUN apt-get update && apt-get install -y \
     git \
     curl \
-    #    && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
-    #    && apt-get install -y nodejs \
+    ca-certificates \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean \
     && rm -rf /tmp/* /var/tmp/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,6 @@
     "options": ["--no-cache"]
   },
   "features": {
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "24"
-    },
     "ghcr.io/devcontainers/features/aws-cli:1": {
       "version": "latest"
     },


### PR DESCRIPTION
## 前提

### 背景
devcontainerのNode.jsインストールには `ghcr.io/devcontainers/features/node:1` というdevcontainer featureを利用していた。

### 課題
ベースイメージ（`mcr.microsoft.com/devcontainers/python:3.12-bookworm`）には古いYarnリポジトリの設定が残っており、`apt-get update` 実行時にリポジトリエラーが発生する場合があった。また、devcontainer featuresとDockerfileのapt処理が干渉する可能性があった。

## 目的

devcontainer起動時のNode.jsインストールを安定させ、ビルドエラーを防ぐ。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `.devcontainer/Dockerfile` | 問題のあるYarnリポジトリを事前に削除する処理を追加。`ca-certificates` を追加し、nodesource経由でNode.js 24を直接インストールするよう変更。コメントアウトされていた古いインストールコードを削除。 |
| `.devcontainer/devcontainer.json` | `ghcr.io/devcontainers/features/node:1` featureを削除（Dockerfile側でインストールするため不要）。 |

## 変更のスコープ

**含む:**
- devcontainerのNode.jsインストール方式の変更

**含まない:**
- アプリケーションコードの変更
- CI/CDパイプラインの変更

## 変更の構造図

```mermaid
flowchart TD
  subgraph "変更前"
    A["devcontainer.json\n(features: node:1 v24)"] --> B["devcontainer feature\nによるNode.jsインストール"]
    C["Dockerfile\n(Node.jsインストールはコメントアウト)"] --> D["Node.jsなし"]
  end

  subgraph "変更後"
    E["devcontainer.json\n(node featureを削除)"] --> F["featureによる\nインストールなし"]
    G["Dockerfile"] --> H["Yarnリポジトリを削除"]
    H --> I["ca-certificates インストール"]
    I --> J["nodesource setup_24.x 実行"]
    J --> K["Node.js 24 インストール完了"]
  end
```

## 動作確認方法

1. このブランチをチェックアウトしてdevcontainerを再ビルドする
   ```bash
   # VS Code: "Dev Containers: Rebuild Container" を実行
   ```
2. コンテナ内で Node.js のバージョンを確認する
   ```bash
   node --version
   # v24.x.x が表示されることを確認
   ```

## リスク・注意点

- nodesourceのセットアップスクリプト（`setup_24.x`）はインターネットアクセスが必要なため、ネットワーク制限のある環境では失敗する可能性がある
- devcontainer featuresからDockerfileへの移行により、Node.jsのインストールタイミングがビルド時に固定される（featuresによる遅延インストールではなくなる）