### PR TITLE
fix: Bedrock モデルへの max_tokens を 8192 から 64000 に拡大

### DIFF
--- a/src/vtt2minutes/bedrock.py
+++ b/src/vtt2minutes/bedrock.py
@@ -454,7 +454,7 @@ class BedrockMeetingMinutesGenerator:
             body = json.dumps(
                 {
                     "anthropic_version": "bedrock-2023-05-31",
-                    "max_tokens": 8192,
+                    "max_tokens": 64000,
                     "messages": [{"role": "user", "content": prompt}],
                     "temperature": 0.3,
                 }


### PR DESCRIPTION
## 前提

### 背景

Amazon Bedrock 上の Claude モデルを使って議事録を生成する際、レスポンスに使用できるトークン数は `max_tokens` パラメータで制限されている。

### 課題

従来の `max_tokens: 8192` では、会議の内容が長い場合に生成される議事録がトークン上限に達し、出力が途中で切れる可能性があった。直前のコミット（f3e19b4）で 4000 → 8192 に拡張されたが、長時間の会議や詳細な議事録には依然として不十分なケースがある。

---

## 目的

Claude モデルが生成できる議事録の最大長を拡大し、長時間会議の内容を途切れなく出力できるようにする。

---

## 変更内容

| ファイル | 変更箇所 | 変更前 | 変更後 |
|---|---|---|---|
| `src/vtt2minutes/bedrock.py` | `_invoke_model` メソッド内の Bedrock API リクエストボディ | `"max_tokens": 8192` | `"max_tokens": 64000` |

```mermaid
flowchart LR
    subgraph "変更前"
        A1["VTTファイル"] --> B1["Bedrock API リクエスト\nmax_tokens: 8192"]
        B1 --> C1["議事録（最大 8,192 トークン）"]
    end

    subgraph "変更後"
        A2["VTTファイル"] --> B2["Bedrock API リクエスト\nmax_tokens: 64000"]
        B2 --> C2["議事録（最大 64,000 トークン）"]
    end

    style B1 fill:#f99,stroke:#c33
    style B2 fill:#9f9,stroke:#3c3
    style C1 fill:#f99,stroke:#c33
    style C2 fill:#9f9,stroke:#3c3
```

---

## 変更のスコープ

**含む範囲:**
- `bedrock.py` の Claude モデル向けリクエストボディの `max_tokens` 値の変更のみ

**含まない範囲:**
- 他のモデル（非 Claude）向けリクエストの変更
- `max_tokens` を設定可能なオプション・パラメータ化（別 Issue での対応を検討）

---

## 動作確認方法

1. 既存のテストが通過することを確認:
   ```bash
   uv run --frozen pytest
   ```
2. 実際の長い VTT ファイルを使って議事録生成を実行し、出力が途切れないことを確認:
   ```bash
   uv run vtt2minutes <長い会議のVTTファイル> --output minutes.md
   ```

---

## リスク・注意点

- `max_tokens: 64000` は Claude 3 系モデルがサポートする最大値の範囲内だが、モデルバージョンによっては上限が異なる場合がある。利用するモデルが 64,000 トークンの出力をサポートしているか事前に確認すること。
- トークン数が増えると API コストも増加する可能性があるが、実際の出力トークン数は生成内容に依存するため、通常の会議ではコストへの影響は軽微と想定される。
